### PR TITLE
cambios en paginas de proyectos donde estaba el llamado del js

### DIFF
--- a/templates/ciclos_economicos.html
+++ b/templates/ciclos_economicos.html
@@ -15,8 +15,7 @@
 
     <link rel="stylesheet" href="{% static 'css/ciclos_economicos.css' %}" />
     <link rel="stylesheet" href="{% static 'css/website.css' %}" />
-		<link rel="stylesheet" href="{% static 'css/forms/jquery-ui_1.10.2.css' %}" />
-	<script src="{% static 'js/resetSession.js' %}"></script>
+	<link rel="stylesheet" href="{% static 'css/forms/jquery-ui_1.10.2.css' %}" />
 
   </head>
 

--- a/templates/demograficos.html
+++ b/templates/demograficos.html
@@ -24,7 +24,6 @@
 		<link rel="stylesheet" href="{% static 'css/forms/jquery-ui_1.10.2.css' %}" />
 
         <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-        <script src="{% static 'js/resetSession.js' %}"></script>
 
 
     <style type="text/css">

--- a/templates/energy_data.html
+++ b/templates/energy_data.html
@@ -19,7 +19,6 @@
     <!-- JS -->
     <script> window.API_URL = "{{ api|escapejs }}";</script>
     <script src="{% static 'js/exportcsv.js' %}" defer></script>
-    <script src="{% static 'js/resetSession.js' %}"></script>
 
     <!-- Ajustes de alineación: centro pero texto alineado a la izquierda dentro del contenedor -->
     <style>

--- a/templates/home.html
+++ b/templates/home.html
@@ -5,7 +5,6 @@
 <html data-wf-domain="www.pr.gov" data-wf-page="60ef3152d22749da0b6a9065" data-wf-site="60ddbc422188bb3fab87d219" lang="es">
     <head>
         <meta charset="utf-8"/>
-        <script src="{% static 'js/resetSession.js' %}"></script>
         <title>PR.gov</title>
         <meta content="width=device-width, initial-scale=1" name="viewport"/>
         <link href="https://assets-global.website-files.com/60ddbc422188bb3fab87d219/css/pr-gov.9f47b10d6.css" rel="stylesheet" type="text/css"/>

--- a/templates/imports_exports.html
+++ b/templates/imports_exports.html
@@ -22,7 +22,6 @@
     <!-- JS -->
     <script> window.API_URL = "{{ api|escapejs }}";</script>
     <script src="{% static 'js/exportcsv.js' %}" defer></script>
-    <script src="{% static 'js/resetSession.js' %}"></script>
 </head>
 
 

--- a/templates/indice_desarrollo_humano.html
+++ b/templates/indice_desarrollo_humano.html
@@ -14,7 +14,6 @@
 
         <link rel="stylesheet" href="{% static 'css/indicadores.css' %}">
         <link rel="stylesheet" href="{% static 'css/website.css' %}" />
-        <script src="{% static 'js/resetSession.js' %}"></script>
         <!-- <link rel="stylesheet" type="text/css" href="{% static 'css/indice.css' %}"> -->
 
         <script src="{% static 'js/idh_download.js' %}" defer></script>

--- a/templates/macro.html
+++ b/templates/macro.html
@@ -16,7 +16,6 @@
         <!-- CSS -->
         <link rel="stylesheet" href="{% static 'css/macro.css' %}">
         <link rel="stylesheet" href="{% static 'css/website.css' %}">
-        <script src="{% static 'js/resetSession.js' %}"></script>
     </head>
 
     <body>

--- a/templates/productos_ranking.html
+++ b/templates/productos_ranking.html
@@ -21,7 +21,6 @@
     <!-- JS -->
     <script> window.API_URL = "{{ api|escapejs }}";</script>
     <script src="{% static 'js/exportcsv.js' %}" defer></script>
-    <script src="{% static 'js/resetSession.js' %}"></script>
   </head>
 
   <body>

--- a/templates/proyecciones.html
+++ b/templates/proyecciones.html
@@ -5,7 +5,6 @@
     <head>
         <meta charset="utf-8"/>
         <title>PR.gov</title>
-        <script src="{% static 'js/resetSession.js' %}"></script>
         <meta content="width=device-width, initial-scale=1" name="viewport"/>
         <link href="https://assets-global.website-files.com/60ddbc422188bb3fab87d219/css/pr-gov.9f47b10d6.css" rel="stylesheet" type="text/css"/>
         <link href="https://fonts.googleapis.com" rel="preconnect"/>

--- a/templates/proyectos.html
+++ b/templates/proyectos.html
@@ -6,7 +6,6 @@
 
 <head>
     <meta charset="utf-8" />
-    <script src="{% static 'js/resetSession.js' %}"></script>
     <title>PR.gov</title>
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     <link href="https://assets-global.website-files.com/60ddbc422188bb3fab87d219/css/pr-gov.9f47b10d6.css"

--- a/templates/salud_ingresos_educacion.html
+++ b/templates/salud_ingresos_educacion.html
@@ -14,7 +14,6 @@
 
         <link rel="stylesheet" type="text/css" href="{% static 'css/salud_ingresos_educacion.css' %}">
         <link rel="stylesheet" href="{% static 'css/website.css' %}" />
-        <script src="{% static 'js/resetSession.js' %}"></script>
     </head>
 
     <body>


### PR DESCRIPTION
se quita el llamado del archivo js para todas las paginas de proyectos debido a que generaría error, debido a que fue borrado por que no va a ser utilizado.